### PR TITLE
Fixed arguments for built-in commands

### DIFF
--- a/ish2/ish.c
+++ b/ish2/ish.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv, char **envp)
                 //       our shell in a pipe sequence.
                 // ?
 
-                char *directory = argument_count == 0 ?  home : arguments[1];
+                char *directory = argument_count == 1 ?  home : arguments[1];
                 if (directory) {
                     chdir(directory);
                 }
@@ -118,7 +118,7 @@ int main(int argc, char **argv, char **envp)
                 // ?
 
                 int exit_status =
-                    argument_count == 0 ?
+                    argument_count == 1 ?
                         0 : ish_get_integer_from_cstring(
                                 arguments[1]
                             );


### PR DESCRIPTION
Original ish2 had problems with argument count for built-in commands. It assumed that no arguments means `argument_count` to be 0, instead of 1 (ignored the command name). Hence in following `if` statements only one branch was resolvable. 
https://github.com/toksaitov/syscall-project/blob/840a0642be0ff31d590c7d55c9ba3506bcd94b0e/ish2/ish.c#L102-L105
https://github.com/toksaitov/syscall-project/blob/840a0642be0ff31d590c7d55c9ba3506bcd94b0e/ish2/ish.c#L120-L125
This mistake led to the incorrect behaviour of the `exit` command, which queried the nonexistent `argument[1]` and resulted in 255 exit code instead of 0, and `cd` command refused to change dir to home. This PR fixes these bugs.

Credit to Sardar Sultanaliev, who pointed to the incorrect exit code.