### PR TITLE
Change read result comparison operand to strict

### DIFF
--- a/ish/ish.c
+++ b/ish/ish.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv, char **envp)
 
         `man 2 read`
     */
-    while (read(0, input, Max_Input_String_Length) >= 0) {
+    while (read(0, input, Max_Input_String_Length) > 0) {
         /*
             Mark the 'new line' character as the end of the C string.
         */


### PR DESCRIPTION
In current version of `ish.c` file on line [106](https://github.com/toksaitov/syscall-project/blob/c0e96a8edc8a98c429928ea45992471b9d944c47/ish/ish.c#L106)

there is statement
```c
while (read(0, input, Max_Input_String_Length) >= 0)
```
but read returning 0 means EOF, so it provokes problem described in issue #3. 

Changing this to 
```c
while (read(0, input, Max_Input_String_Length) > 0)
```

Solves the problem and also allows to exit ish via `Ctrl+D` shortcut.