### PR TITLE
Add ish_syscalls.riscv64.c to $(SPECIAL_OBJECTS) in Makefile

### DIFF
--- a/ish/Makefile
+++ b/ish/Makefile
@@ -14,7 +14,7 @@ $(TARGET) : $(OBJECTS) $(SPECIAL_OBJECTS)
 
 $(OBJECTS) : %.o : %.c ish_common.h
 
-$(SPECIAL_OBJECTS) : %.o : %.c ish_syscalls.amd64.c ish_syscalls.aarch64.c ish_common.h
+$(SPECIAL_OBJECTS) : %.o : %.c ish_syscalls.amd64.c ish_syscalls.aarch64.c ish_syscalls.riscv64.c ish_common.h
 
 .PHONY : clean
 clean :


### PR DESCRIPTION
Absence of ish_syscalls.riscv64.c in $(SPECIAL_OBJECTS) in Makefile was the reason why this file was not changing without 'make clean'.